### PR TITLE
Update version only on release events

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,13 +20,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
-      - name: Build
+      - name: Update version
+        if: github.event_name != 'pull_request'
         run: |
           export TAG=${GITHUB_REF#refs/*/}
           export TAG=${TAG#"v"}
-          echo "start to package with ${TAG}"
+          echo "change the version to ${TAG}"
           jq '.version = env.TAG' package.json > package.json.new && mv package.json.new package.json
-
+      - name: Build
+        run: |
           npm i
           npm install -g @vscode/vsce
           vsce package


### PR DESCRIPTION
Related to #4

Updates the `.github/workflows/build.yaml` to conditionally update the version in `package.json` only for release events.

- Separates the version update logic into a new step named "Update version" that runs conditionally if the event is not a pull request.
- Removes the version update logic from the "Build" step to ensure the version in `package.json` is only updated during release events, aligning with the issue's requirement.
- Maintains the condition for the "Publish" step to exclude pull requests, ensuring it only runs for push events.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LinuxSuRen/vscode-webhook/issues/4?shareId=6c3cc17c-5490-400e-9471-9ca5fc77cee7).